### PR TITLE
Add router for index server; replace BaseManager with sdk directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: start
 start:
 	# You need to set OPENAPI_API_KEY environment
-	PYTHONPATH=. python app/launch.py
+	PYTHONPATH=. python app/main.py
 
 .PHONY: clean
 clean:

--- a/app/launch.py
+++ b/app/launch.py
@@ -13,7 +13,7 @@ def index_server_main() -> Process:
     return index_server_process
 
 
-def main():
+def old_main():
     index_process = None
     try:
         index_process = index_server_main()
@@ -25,6 +25,14 @@ def main():
     except KeyboardInterrupt:
         if index_process:
             index_process.terminate()
+        # Re-raise to caller
+        raise
+
+
+def main():
+    try:
+        api_main()
+    except KeyboardInterrupt:
         # Re-raise to caller
         raise
 

--- a/app/llama_index_server/index_server.py
+++ b/app/llama_index_server/index_server.py
@@ -1,4 +1,3 @@
-import os
 import time
 from typing import Any, Dict
 from multiprocessing.managers import BaseManager

--- a/app/llama_index_server/main.py
+++ b/app/llama_index_server/main.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from app.utils.openapi import patch_openapi
+from app.llama_index_server.router import index_router
+from app.utils.log_util import logger
+import uvicorn
+
+app = FastAPI(
+    title="Front end from llama-index",
+    servers=[
+        {
+            "url": "http://127.0.0.1:8082",
+            "description": "Local environment for llama index server",
+        },
+    ],
+    version="0.0.1",
+)
+
+# Enable CORS for *
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+# Remove 422 error in the docs
+patch_openapi(app)
+
+prefix = "/api/v1"
+app.include_router(index_router, prefix=prefix)
+
+
+def main():
+    # show if there is any python process running bounded to the port
+    # ps -fA | grep python
+    logger.info("Start llama index server")
+    uvicorn.run("app.llama_index_server.main:app", host="127.0.0.1", port=8082)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/llama_index_server/router.py
+++ b/app/llama_index_server/router.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, Request
+
+from app.llama_index_server.index_server import delete_doc as _delete_doc
+from app.llama_index_server.index_server import (
+    insert_text_into_index,
+    insert_file_into_index,
+)
+from app.llama_index_server.index_server import get_document as _get_document
+from app.llama_index_server.index_server import query_index
+
+index_router = APIRouter(
+    prefix="/index",
+    tags=["index server API"],
+)
+
+
+@index_router.post("/query", description="")
+async def query(request: Request):
+    json = await request.json()
+    question = json["question"]
+    return query_index(question)
+
+
+@index_router.post("/insertion")
+async def insert_doc_to_index(request: Request):
+    """Insert document into index
+
+    Args:
+        doc_type: one of [TEXT, File]
+    """
+    json = await request.json()
+    doc_type = json.get("doc_type", "Unknown").upper()
+    doc_id = json.get("doc_id")
+    if doc_type == "TEXT":
+        text = json["text"]
+        insert_text_into_index(text, doc_id)
+    elif doc_type == "FILE":
+        path = json["path"]
+        insert_file_into_index(path, doc_id=doc_id)
+    else:
+        raise ValueError(f"Unknown doc_type: {doc_type}")
+
+
+@index_router.delete("/{doc_id}")
+async def delete_doc(doc_id: str):
+    return _delete_doc(doc_id)
+
+
+@index_router.get("/documents/{doc_id}")
+async def get_document(doc_id: str):
+    return _get_document(doc_id)

--- a/app/routers/qa.py
+++ b/app/routers/qa.py
@@ -8,7 +8,7 @@ from app.data.messages.qa import (
     DocumentResponse,
 )
 from app.utils.log_util import logger
-from app.utils import manager_util
+from app.utils.service import get_service
 
 qa_router = APIRouter(
     prefix="/qa",
@@ -25,8 +25,8 @@ qa_router = APIRouter(
 async def answer_question(req: QuestionAnsweringRequest):
     logger.info("answer question from user")
     query_text = req.question
-    manager = manager_util.get_manager()
-    data = manager.query_index(query_text)._getvalue()
+    service = get_service("LLAMA_INDEX_SERVICE")
+    data = service.query_index(query_text)
     answer = Answer(**data)
     return QuestionAnsweringResponse(data=answer)
 
@@ -38,8 +38,8 @@ async def answer_question(req: QuestionAnsweringRequest):
 )
 async def get_document(req: DocumentRequest):
     logger.info(f"get document for doc_id {req.doc_id}")
-    manager = manager_util.get_manager()
-    document = manager.get_document(req.doc_id)._getvalue()
+    service = get_service("LLAMA_INDEX_SERVICE")
+    document = service.get_document(req.doc_id)
     return DocumentResponse(data=document)
 
 
@@ -50,6 +50,6 @@ async def get_document(req: DocumentRequest):
 )
 async def delete_doc(doc_id: str = Path(..., title="The ID of the document to delete")):
     logger.info(f"Delete doc for {doc_id}")
-    manager = manager_util.get_manager()
-    manager.delete_doc(doc_id)
+    service = get_service("LLAMA_INDEX_SERVICE")
+    service.delete_doc(doc_id)
     return DeleteDocumentResponse(msg=f"Successfully deleted {doc_id}")

--- a/app/utils/log_util.py
+++ b/app/utils/log_util.py
@@ -10,4 +10,6 @@ logging.basicConfig(
     format="[%(asctime)s] [%(levelname)s] [%(filename)s:%(lineno)d:%(funcName)s] %(message)s",
 )
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+logger.propagate = True
+handler = logging.StreamHandler(stream=sys.stdout)
+logger.addHandler(handler)

--- a/app/utils/service.py
+++ b/app/utils/service.py
@@ -1,0 +1,31 @@
+from app.llama_index_server.index_server import query_index as _query_index
+from app.llama_index_server.index_server import insert_file_into_index as insert_file
+from app.llama_index_server.index_server import insert_text_into_index as insert_text
+from app.llama_index_server.index_server import delete_doc as _delete_doc
+from app.llama_index_server.index_server import get_document as _get_document
+
+
+class LLamaIndexService:
+    def query_index(self, question):
+        return _query_index(question)
+
+    def insert_text_into_index(self, text, doc_id):
+        return insert_text(text, doc_id)
+
+    def insert_file_into_index(self, path, doc_id):
+        return insert_file(path, doc_id)
+
+    def delete_doc(self, doc_id):
+        return _delete_doc(doc_id)
+
+    def get_document(self, doc_id):
+        return _get_document(doc_id)
+
+
+__GLOBAL_SERIVCE__ = {"LLAMA_INDEX_SERVICE": LLamaIndexService()}
+
+
+def get_service(service_name: str):
+    if service_name not in __GLOBAL_SERIVCE__:
+        raise ValueError(f"Unknown service: {service_name}")
+    return __GLOBAL_SERIVCE__[service_name]


### PR DESCRIPTION
- Add router for llama index service
- In qa fastapi application, directly call llama index related function
- Add a wrapper for llama index service: We can change the implementation for calling functions into remote API calls if we want to do that